### PR TITLE
Add GitHub Pages index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Clean Code Practice
+
+Welcome to the learning hub for my clean code journey. This repository serves as a sandbox where I apply software engineering principles to a simple Library Management System. The goal is to focus on writing maintainable, testable code while exploring SOLID and other best practices.
+
+## Why this project?
+
+- **Experimentation** – Try out design ideas without the overhead of a large production codebase.
+- **SOLID in Action** – Apply the Single Responsibility, Open/Closed, Liskov, Interface Segregation and Dependency Inversion principles.
+- **Documentation Driven** – Record decisions and lessons learned through Markdown files.
+- **Testing Culture** – Write unit tests early to reinforce good habits.
+
+## What to expect
+
+The codebase starts small and evolves through deliberate refactoring. Each commit aims to demonstrate clean architecture techniques, from separation of concerns to dependency injection. The `/docs` directory contains additional guides and notes collected along the way.
+
+I hope these notes help you (and future me) understand how thoughtful structure can keep even a simple project understandable and adaptable.


### PR DESCRIPTION
## Summary
- add docs/README as the GitHub Pages index describing project goals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68821a9f4fd4832bb8d39a5cb6f448b8